### PR TITLE
lingmor: ComparisonDegree, VerbalVoice, VerbalMood, Tense, Person

### DIFF
--- a/nie-ontologies_shared/linguistic-morphology-ontology-knora.ttl
+++ b/nie-ontologies_shared/linguistic-morphology-ontology-knora.ttl
@@ -39,7 +39,7 @@
 lingmor:SyntacticWordForm
 	a owl:Class;
 	rdfs:label "syntactic word form"@en, "syntaktische Wortform"@de;
-	rdfs:comment """Linguistic concept unifying infinite syntactic words with identical literal."""@en;
+	rdfs:comment """Linguistic concept unifying occurrences of syntactic words with identical literal and grammemes."""@en;
 	skos:note """A sentence can contain 2 times the syntactic word 'sun', unified by 1 syntactic word form 'sun'."""@en;
 	rdfs:subClassOf ling:Concept, [
 		a owl:Restriction; owl:onProperty lingmor:hasLexeme; owl:minCardinality "0"^^xsd:nonNegativeInteger], [

--- a/nie-ontologies_shared/linguistic-morphology-ontology-knora.ttl
+++ b/nie-ontologies_shared/linguistic-morphology-ontology-knora.ttl
@@ -44,12 +44,12 @@ lingmor:SyntacticWordForm
 	rdfs:subClassOf ling:Concept, [
 		a owl:Restriction; owl:onProperty lingmor:hasLexeme; owl:minCardinality "0"^^xsd:nonNegativeInteger], [
 		a owl:Restriction; owl:onProperty lingmor:hasLexemeValue; owl:minCardinality "0"^^xsd:nonNegativeInteger], [
-		a owl:Restriction; owl:onProperty lingmor:hasGrammaticalGender; owl:minCardinality "0"^^xsd:nonNegativeInteger], [
-		a owl:Restriction; owl:onProperty lingmor:hasGrammaticalGenderValue; owl:minCardinality "0"^^xsd:nonNegativeInteger], [
-		a owl:Restriction; owl:onProperty lingmor:hasCase; owl:minCardinality "0"^^xsd:nonNegativeInteger], [
-		a owl:Restriction; owl:onProperty lingmor:hasCaseValue; owl:minCardinality "0"^^xsd:nonNegativeInteger], [
-		a owl:Restriction; owl:onProperty lingmor:hasNumber; owl:minCardinality "0"^^xsd:nonNegativeInteger], [
-		a owl:Restriction; owl:onProperty lingmor:hasNumberValue; owl:minCardinality "0"^^xsd:nonNegativeInteger], [
+#		a owl:Restriction; owl:onProperty lingmor:hasGrammaticalGender; owl:minCardinality "0"^^xsd:nonNegativeInteger], [
+#		a owl:Restriction; owl:onProperty lingmor:hasGrammaticalGenderValue; owl:minCardinality "0"^^xsd:nonNegativeInteger], [
+#		a owl:Restriction; owl:onProperty lingmor:hasCase; owl:minCardinality "0"^^xsd:nonNegativeInteger], [
+#		a owl:Restriction; owl:onProperty lingmor:hasCaseValue; owl:minCardinality "0"^^xsd:nonNegativeInteger], [
+#		a owl:Restriction; owl:onProperty lingmor:hasNumber; owl:minCardinality "0"^^xsd:nonNegativeInteger], [
+#		a owl:Restriction; owl:onProperty lingmor:hasNumberValue; owl:minCardinality "0"^^xsd:nonNegativeInteger], [
 		a owl:Restriction; owl:onProperty lingmor:hasPartOfSpeech; owl:minCardinality "0"^^xsd:nonNegativeInteger ], [
 		a owl:Restriction; owl:onProperty lingmor:hasPartOfSpeechValue; owl:minCardinality "0"^^xsd:nonNegativeInteger ].
 
@@ -111,6 +111,186 @@ lingmor:NeuterGrammaticalGender
 	skos:note """E.g. in Indoeuropean languages."""@en;
 #	owl:sameAs gold:NeuterGender;
 	rdfs:subClassOf lingmor:GrammaticalGender.
+
+lingmor:ComparisonDegree
+	a owl:Class;
+	rdfs:label "comparison degree"@en, "Komparationsstufe"@de;
+	rdfs:comment """Degree of comparison in adjectives or adverbs."""@en;
+	rdfs:subClassOf ling:Concept. #° lingmor:MorphologicalConcept
+
+lingmor:Positive
+	a owl:Class;
+	rdfs:label "positive"@en, "Positiv"@de;
+	rdfs:comment """Base degree of adjective comparison."""@en;
+	rdfs:subClassOf lingmor:ComparisonDegree.
+	
+lingmor:Comparative
+	a owl:Class;
+	rdfs:label "comparative"@en, "Komparativ"@de;
+	rdfs:comment """Degree of adjective comparison that sets two or more entities into relation."""@en;
+	rdfs:subClassOf lingmor:ComparisonDegree.
+	
+lingmor:Superlative
+	a owl:Class;
+	rdfs:label "superlative"@en, "Superlativ"@de;
+	rdfs:comment """Degree of adjective comparison that lies at the end of the scale."""@en;
+	rdfs:subClassOf lingmor:ComparisonDegree.
+
+lingmor:VerbalVoice
+	a owl:Class;
+	rdfs:label "verbal voice"@en, "Diathese"@de;
+	rdfs:comment """Property of verb forms that specifies the roles of the dependent entities."""@en;
+#	owl:sameAs gold:VoiceProperty;
+	rdfs:subClassOf ling:Concept. #° lingmor:MorphologicalConcept
+
+lingmor:ActiveVoice
+	a owl:Class;
+	rdfs:label "active voice"@en, "aktiv"@de;
+	rdfs:comment """Voice that (prototypically) sets the subject as the agent."""@en;
+#	owl:sameAs gold:ActiveVoice;
+	rdfs:subClassOf lingmor:VerbalVoice.
+	
+lingmor:PassiveVoice
+	a owl:Class;
+	rdfs:label "passive voice"@en, "passiv"@de;
+	rdfs:comment """Voice that (prototypically) sets the subject as the patient."""@en;
+#	owl:sameAs gold:PassiveVoice;
+	rdfs:subClassOf lingmor:VerbalVoice.
+	
+lingmor:MedialVoice
+	a owl:Class;
+	rdfs:label "medial voice"@en, "medial"@de;
+	rdfs:comment """."""@en;
+	rdfs:subClassOf lingmor:VerbalVoice.
+	
+lingmor:StaticVoice
+	a owl:Class;
+	rdfs:label "static voice"@en, "statisch"@de;
+	rdfs:comment """."""@en;
+	rdfs:subClassOf lingmor:VerbalVoice.
+
+lingmor:VerbalMood
+	a owl:Class;
+	rdfs:label "verbal mood"@en, "verbaler Modus"@de;
+	rdfs:comment """Property of verbs indicating real or hypothetic utterances."""@en;
+	rdfs:subClassOf ling:Concept. #° lingmor:MorphologicalConcept
+
+lingmor:ConditionalMood
+	a owl:Class;
+	rdfs:label "conditional mood"@en, "Konditional"@de;
+	rdfs:comment """Verbal mood expressiong conditions."""@en;
+	rdfs:subClassOf lingmor:VerbalMood.
+	
+lingmor:ImperativeMood
+	a owl:Class;
+	rdfs:label "imperative mood"@en, "Imperativ"@de;
+	rdfs:comment """Verbal mood expressing orders."""@en;
+	rdfs:subClassOf lingmor:VerbalMood.
+	
+lingmor:IndicativeMood
+	a owl:Class;
+	rdfs:label "indicative mood"@en, "Indikativ"@de;
+	rdfs:comment """Verbal mood for stating facts."""@en;
+	rdfs:subClassOf lingmor:VerbalMood.	
+	
+lingmor:InjuncitveMood
+	a owl:Class;
+	rdfs:label "injunctive mood"@en, "Injunktiv"@de;
+	rdfs:comment """Verbal mood ... ."""@en;
+	rdfs:subClassOf lingmor:VerbalMood.
+
+lingmor:OptativeMood
+	a owl:Class;
+	rdfs:label "optative mood"@en, "Optativ"@de;
+	rdfs:comment """Verbal mood indicating wishes."""@en;
+	rdfs:subClassOf lingmor:VerbalMood.
+	
+lingmor:PrecativeMood
+	a owl:Class;
+	rdfs:label "precative mood"@en, "Präkativ"@de;
+	rdfs:comment """Verbal mood ... ."""@en;
+	rdfs:subClassOf lingmor:VerbalMood.
+	
+lingmor:SubjunctiveMood
+	a owl:Class;
+	rdfs:label "subjunctive mood"@en, "Subjunktiv"@de;
+	rdfs:comment """Verbal mood ... ."""@en;
+	rdfs:subClassOf lingmor:VerbalMood.
+
+lingmor:Tense
+	a owl:Class;
+	rdfs:label "tense"@en, "Tempus"@de;
+	rdfs:comment """Degree of comparison in adjectives or adverbs."""@en;
+#	owl:sameAs gold:TenseProperty;
+	rdfs:subClassOf ling:Concept. #° lingmor:MorphologicalConcept
+
+lingmor:Aorist
+	a owl:Class;
+	rdfs:label "aorist"@en, "Aorist"@de;
+	rdfs:comment """Degree of comparison in adjectives or adverbs."""@en;
+	rdfs:subClassOf lingmor:Tense.
+
+lingmor:Future
+	a owl:Class;
+	rdfs:label "future"@en, "Futur"@de;
+	rdfs:comment """Degree of comparison in adjectives or adverbs."""@en;
+#	owl:sameAs gold:FutureTense;
+	rdfs:subClassOf lingmor:Tense.
+
+lingmor:Imperfect
+	a owl:Class;
+	rdfs:label "imperfect"@en, "Imperfekt"@de;
+	rdfs:comment """Degree of comparison in adjectives or adverbs."""@en;
+	rdfs:subClassOf lingmor:Tense.
+
+lingmor:Perfect
+	a owl:Class;
+	rdfs:label "perfect"@en, "Perfekt"@de;
+	rdfs:comment """Degree of comparison in adjectives or adverbs."""@en;
+#	owl:sameAs gold:PerfectTense;
+	rdfs:subClassOf lingmor:Tense.
+
+lingmor:Pluperfect
+	a owl:Class;
+	rdfs:label "pluperfect"@en, "Plusquamperfekt"@de;
+	rdfs:comment """Degree of comparison in adjectives or adverbs."""@en;
+#	owl:sameAs gold:PastInPastTense;
+	rdfs:subClassOf lingmor:Tense.
+
+lingmor:Present
+	a owl:Class;
+	rdfs:label "present"@en, "Präsens"@de;
+	rdfs:comment """Degree of comparison in adjectives or adverbs."""@en;
+#	owl:sameAs gold:PresentTense;
+	rdfs:subClassOf lingmor:Tense.
+
+lingmor:Person
+	a owl:Class;
+	rdfs:label "person"@en, "Person"@de;
+	rdfs:comment """Property indicating the relation between an entity in an utterance and the speaker."""@en;
+#	owl:sameAs gold:PersonProperty;
+	rdfs:subClassOf ling:Concept. #° lingmor:MorphologicalConcept
+
+lingmor:FirstPerson
+	a owl:Class;
+	rdfs:label "1st person"@en, "1. Person"@de;
+	rdfs:comment """Mentioned entitiy overlaps with speaker."""@en;
+#	owl:sameAs gold:FirstPerson;
+	rdfs:subClassOf lingmor:Person.
+	
+lingmor:SecondPerson
+	a owl:Class;
+	rdfs:label "2nd person"@en, "2. Person"@de;
+	rdfs:comment """Mentioned entity overlaps with listener."""@en;
+#	owl:sameAs gold:SecondPerson;
+	rdfs:subClassOf lingmor:Person.
+	
+lingmor:ThirdPerson
+	a owl:Class;
+	rdfs:label "3rd person"@en, "3. Person"@de;
+	rdfs:comment """Degree of comparison in adjectives or adverbs."""@en;
+#	owl:sameAs gold:ThirdPerson;
+	rdfs:subClassOf lingmor:Person.
 
 lingmor:Case
 	a owl:Class;
@@ -464,6 +644,96 @@ lingmor:hasGrammaticalGenderValue
 	a owl:ObjectProperty;
 	rdfs:label "has grammatical gender - statement"@en, "hat grammatisches Genus - Festlegung"@de;
 	rdfs:comment """Relating a syntactic word form to a reification statement of the relation between the syntactic word form and its grammatical gender."""@en;
+	rdfs:subPropertyOf knora-base:hasLinkToValue;
+	knora-base:subjectClassConstraint lingmor:SyntacticWordForm;
+	knora-base:objectClassConstraint knora-base:LinkValue.
+
+lingmor:hasComparisonDegree
+	a owl:ObjectProperty;
+	rdfs:label "has degree"@en, "hat Komparationsstufe"@de;
+	rdfs:comment """Relating a wordform to a comparison degree."""@en;
+	rdfs:domain lingmor:SyntacticWordForm;
+	rdfs:range lingmor:ComparisonDegree;
+	rdfs:subPropertyOf knora-base:hasLinkTo;
+	knora-base:subjectClassConstraint lingmor:SyntacticWordForm;
+	knora-base:objectClassConstraint lingmor:ComparisonDegree.
+
+lingmor:hasComparisonDegreeValue
+	a owl:ObjectProperty;
+	rdfs:label "has degree - statement"@en, "hat Komparationsstufe - Festlegung"@de;
+	rdfs:comment """Relating a wordform to a comparison degree - reification."""@en;
+	rdfs:subPropertyOf knora-base:hasLinkToValue;
+	knora-base:subjectClassConstraint lingmor:SyntacticWordForm;
+	knora-base:objectClassConstraint knora-base:LinkValue.
+
+lingmor:hasVerbalVoice
+	a owl:ObjectProperty;
+	rdfs:label "has verbal voice"@en, "hat Diathese"@de;
+	rdfs:comment """Relating a verbform to a voice."""@en;
+	rdfs:domain lingmor:SyntacticWordForm;
+	rdfs:range lingmor:VerbalVoice;
+	rdfs:subPropertyOf knora-base:hasLinkTo;
+	knora-base:subjectClassConstraint lingmor:SyntacticWordForm;
+	knora-base:objectClassConstraint lingmor:VerbalVoice.
+
+lingmor:hasVerbalVoiceValue
+	a owl:ObjectProperty;
+	rdfs:label "has verbal voice - statement"@en, "hat Diathese - Festlegung"@de;
+	rdfs:comment """Relating a verbform to a voice - reification."""@en;
+	rdfs:subPropertyOf knora-base:hasLinkToValue;
+	knora-base:subjectClassConstraint lingmor:SyntacticWordForm;
+	knora-base:objectClassConstraint knora-base:LinkValue.
+
+lingmor:hasVerbalMood
+	a owl:ObjectProperty;
+	rdfs:label "has verbal mode"@en, "hat Modus"@de;
+	rdfs:comment """Relating a verbform to mood."""@en;
+	rdfs:domain lingmor:SyntacticWordForm;
+	rdfs:range lingmor:VerbalMood;
+	rdfs:subPropertyOf knora-base:hasLinkTo;
+	knora-base:subjectClassConstraint lingmor:SyntacticWordForm;
+	knora-base:objectClassConstraint lingmor:VerbalMood.
+
+lingmor:hasVerbalMoodValue
+	a owl:ObjectProperty;
+	rdfs:label "has verbal mode - statement"@en, "hat Modus - Festlegung"@de;
+	rdfs:comment """Relating a verbform to mood - reification."""@en;
+	rdfs:subPropertyOf knora-base:hasLinkToValue;
+	knora-base:subjectClassConstraint lingmor:SyntacticWordForm;
+	knora-base:objectClassConstraint knora-base:LinkValue.
+
+lingmor:hasTense
+	a owl:ObjectProperty;
+	rdfs:label "has tense"@en, "hat Tempus"@de;
+	rdfs:comment """Relating a verbform to tense."""@en;
+	rdfs:domain lingmor:SyntacticWordForm;
+	rdfs:range lingmor:Tense;
+	rdfs:subPropertyOf knora-base:hasLinkTo;
+	knora-base:subjectClassConstraint lingmor:SyntacticWordForm;
+	knora-base:objectClassConstraint lingmor:Tense.
+
+lingmor:hasTenseValue
+	a owl:ObjectProperty;
+	rdfs:label "has tense - statement"@en, "hat Tempus - Festlegung"@de;
+	rdfs:comment """Relating a verbform to tense - reification."""@en;
+	rdfs:subPropertyOf knora-base:hasLinkToValue;
+	knora-base:subjectClassConstraint lingmor:SyntacticWordForm;
+	knora-base:objectClassConstraint knora-base:LinkValue.
+
+lingmor:hasPerson
+	a owl:ObjectProperty;
+	rdfs:label "has person"@en, "hat Person"@de;
+	rdfs:comment """Relating a wordform to a person property."""@en;
+	rdfs:domain lingmor:SyntacticWordForm;
+	rdfs:range lingmor:Person;
+	rdfs:subPropertyOf knora-base:hasLinkTo;
+	knora-base:subjectClassConstraint lingmor:SyntacticWordForm;
+	knora-base:objectClassConstraint lingmor:Person.
+
+lingmor:hasPersonValue
+	a owl:ObjectProperty;
+	rdfs:label "has person - statement"@en, "hat Person - Festlegung"@de;
+	rdfs:comment """Relating a wordform to a person property - reification."""@en;
 	rdfs:subPropertyOf knora-base:hasLinkToValue;
 	knora-base:subjectClassConstraint lingmor:SyntacticWordForm;
 	knora-base:objectClassConstraint knora-base:LinkValue.


### PR DESCRIPTION
This PR adds the linguistic-morphologic concepts *comparison degree*, *verbal voice*, *mood*, *tense* and *person* and their most common subclasses.

At the same time, the cardinalities for such properties are removed from lingmor:SyntacticWordForm, so they can be defined on a deeper level (as *finite verb form* etc.).